### PR TITLE
fix Barbed Wire Roll's logic to break when it should; add loot_table

### DIFF
--- a/src/main/java/kelvin/slendermod/block/BarbedWireBlock.java
+++ b/src/main/java/kelvin/slendermod/block/BarbedWireBlock.java
@@ -1,11 +1,7 @@
 package kelvin.slendermod.block;
 
-import kelvin.slendermod.SlenderMod;
-import kelvin.slendermod.registry.BlockRegistry;
 import net.minecraft.block.*;
-import net.minecraft.block.enums.BedPart;
 import net.minecraft.block.enums.DoorHinge;
-import net.minecraft.block.enums.DoubleBlockHalf;
 import net.minecraft.block.piston.PistonBehavior;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
@@ -25,7 +21,6 @@ import net.minecraft.world.BlockView;
 import net.minecraft.world.World;
 import net.minecraft.world.WorldAccess;
 import net.minecraft.world.WorldView;
-import org.jetbrains.annotations.Nullable;
 
 @SuppressWarnings("deprecation")
 public class BarbedWireBlock extends HorizontalFacingBlock {

--- a/src/main/resources/data/slendermod/loot_tables/blocks/barbed_wire_roll.json
+++ b/src/main/resources/data/slendermod/loot_tables/blocks/barbed_wire_roll.json
@@ -1,0 +1,29 @@
+{
+   "type": "minecraft:block",
+   "pools": [
+      {
+         "bonus_rolls": 0.0,
+         "conditions": [
+            {
+               "condition": "minecraft:survives_explosion"
+            }
+         ],
+         "entries": [
+            {
+               "type": "minecraft:item",
+               "conditions": [
+                  {
+                     "block": "slendermod:barbed_wire_roll",
+                     "condition": "minecraft:block_state_property",
+                     "properties": {
+                        "half": "left"
+                     }
+                  }
+               ],
+               "name": "slendermod:barbed_wire_roll"
+            }
+         ],
+         "rolls": 1.0
+      }
+   ]
+}


### PR DESCRIPTION
This should fix the issues seen with barbed wires, 
a somewhat similar approach may be possible with the Dumpster Block.
(It may be better to just use an interface to control them all in one place)



Add a loot table.